### PR TITLE
fix: 修复作物状态信息显示格式异常

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -5,8 +5,8 @@
     <title>🌾 Farm Sim Paradise</title>
     
 <script type="module">
-import init, * as bindings from '/farm_sim-cef47caef6265142.js';
-const wasm = await init({ module_or_path: '/farm_sim-cef47caef6265142_bg.wasm' });
+import init, * as bindings from '/farm_sim-4275549c8da3df51.js';
+const wasm = await init({ module_or_path: '/farm_sim-4275549c8da3df51_bg.wasm' });
 
 
 window.wasmBindings = bindings;
@@ -647,7 +647,7 @@ dispatchEvent(new CustomEvent("TrunkApplicationStarted", {detail: {wasm}}));
     
     
     
-  <link rel="modulepreload" href="/farm_sim-cef47caef6265142.js" crossorigin="anonymous" integrity="sha384-zxHpXSuDBvKu3+i4n3RQGjmQlOA8Xj99fdV7xc6QPk7OGoba2vLWNeiLk1OovJRG"><link rel="preload" href="/farm_sim-cef47caef6265142_bg.wasm" crossorigin="anonymous" integrity="sha384-ZhBK597znwInArIKzlnXzHWf1Gn1NEknzRiDzHn9oF2PQiTxemPY9n+hGmLfjfBU" as="fetch" type="application/wasm"></head>
+  <link rel="modulepreload" href="/farm_sim-4275549c8da3df51.js" crossorigin="anonymous" integrity="sha384-Wryr3idA3Tm7tze+TyhlIinHFciJCnnH5yfFc2nlhshxwCxr0JSQn/8ONudFdNSz"><link rel="preload" href="/farm_sim-4275549c8da3df51_bg.wasm" crossorigin="anonymous" integrity="sha384-Nde/pgDMDMTd1IVlwty/kPIPZBZ7vviDCRmxlXrgLuN3wfmXV7ur4wvry24cMTew" as="fetch" type="application/wasm"></head>
   <body>
     <div class="game-header">
       <h1 class="game-title">🌾 Farm Sim Paradise</h1>

--- a/src/farm.rs
+++ b/src/farm.rs
@@ -120,24 +120,10 @@ impl Farm {
     pub fn get_crop_info(&self, row: usize, col: usize) -> String {
         if row < self.grid.len() && col < self.grid[0].len() {
             let tile = &self.grid[row][col];
-            let message = tile.get_crop_info();
-            let state = match tile.state {
-                TileState::Empty => "empty",
-                TileState::Planted { .. } => "planted",
-                TileState::Mature { .. } => "mature",
-                TileState::Infested { crop } => match crop {
-                    CropType::Wheat => "infested_wheat",
-                    CropType::Corn => "infested_corn",
-                    CropType::Carrot => "infested_carrot",
-                },
-            };            
-            serde_json::to_string(&serde_json::json!({
-                "message": message,
-                "state": state
-            }))
-            .unwrap_or_default()
+            // 直接返回 tile 的信息文本
+            tile.get_crop_info()
         } else {
-            "{}".to_string()
+            "无效位置".to_string()
         }
     }
 


### PR DESCRIPTION
##  问题描述

在游戏中查看地块信息时，提示框显示了不应出现的 JSON 格式内容，而不是用户友好的格式化文本。

**错误显示：**
```
{"message":"🌱 空地\n状态: 可以种植作物\n操作: 拖拽种子到此处进行种植","state":"empty"}
```

**期望显示：**
```
🌱 空地
━━━━━━━━━━━━━━
状态: 可以种植作物
操作: 拖拽种子到此处进行种植
...
```

## 根本原因

在 `get_crop_info()` 方法中，返回值被错误地序列化为 JSON 字符串：

```rust
// 问题代码
serde_json::to_string(&serde_json::json!({
    "message": message,
    "state": state
}))
```

这导致前端直接显示 JSON 字符串，而不是提取其中的 `message` 内容。

##  修复方案 

### 变更内容

1. **修改 `get_crop_info()` 方法**：直接返回格式化的文本内容，而不是 JSON 字符串
2. **保持 API 简洁**：移除不必要的 JSON 包装
3. **提升用户体验**：确保提示框显示清晰的格式化信息

### 代码变更

**修改前：**
```rust
pub fn get_crop_info(&self, row: usize, col: usize) -> String {
    if row < self.grid.len() && col < self.grid[0].len() {
        let tile = &self.grid[row][col];
        let message = tile.get_crop_info();
        let state = match tile.state {
            TileState::Empty => "empty",
            TileState::Planted { .. } => "planted",
            TileState::Mature { .. } => "mature",
            TileState::Infested { crop } => match crop {
                CropType::Wheat => "infested_wheat",
                CropType::Corn => "infested_corn",
                CropType::Carrot => "infested_carrot",
            },
        };
        
        serde_json::to_string(&serde_json::json!({
            "message": message,
            "state": state
        }))
        .unwrap_or_default()
    } else {
        "{}".to_string()
    }
}
```

**修改后：**
```rust
pub fn get_crop_info(&self, row: usize, col: usize) -> String {
    if row < self.grid.len() && col < self.grid[0].len() {
        let tile = &self.grid[row][col];
        tile.get_crop_info()
    } else {
        "无效位置".to_string()
    }
}
```

##  测试

### 测试场景

- [x] 空地块信息显示正确
- [x] 种植中作物信息显示正确
- [x] 成熟作物信息显示正确
- [x] 虫害作物信息显示正确
- [x] 前端提示框显示格式化文本

### 测试步骤

1. 启动游戏
2. 鼠标悬停在不同状态的地块上
3. 验证提示框显示正确的格式化文本
4. 确认不再出现 JSON 格式内容

## 截图 

**修复前：**
![修复前显示 JSON 格式]
![屏幕截图 2025-07-09 153631](https://github.com/user-attachments/assets/e4f570b5-73f1-4237-b004-a92e770191ef)

**修复后：**
![修复后显示格式化文本]
![屏幕截图 2025-07-09 165304](https://github.com/user-attachments/assets/626623f8-18a7-452f-beb4-6391de09b8f2)



## 🏷️ 类型 (Type)

- [x] 🐛 Bug fix


## 🎯 优先级 (Priority)

- [x] 🔥 High - 影响用户体验

**检查清单 (Checklist):**
- [x] 代码已测试
- [x] 代码符合项目风格
- [x] 相关文档已更新
- [x] 无破坏性变更
- [x] 已验证修复效果