### PR TITLE
修复购买高级种子后背包无法显示图片

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -5,8 +5,8 @@
     <title>🌾 Farm Sim Paradise</title>
     
 <script type="module">
-import init, * as bindings from '/farm_sim-4f29181bbdf75b40.js';
-const wasm = await init({ module_or_path: '/farm_sim-4f29181bbdf75b40_bg.wasm' });
+import init, * as bindings from '/farm_sim-4f46c12812251bb1.js';
+const wasm = await init({ module_or_path: '/farm_sim-4f46c12812251bb1_bg.wasm' });
 
 
 window.wasmBindings = bindings;
@@ -647,7 +647,7 @@ dispatchEvent(new CustomEvent("TrunkApplicationStarted", {detail: {wasm}}));
     
     
     
-  <link rel="modulepreload" href="/farm_sim-4f29181bbdf75b40.js" crossorigin="anonymous" integrity="sha384-Wryr3idA3Tm7tze+TyhlIinHFciJCnnH5yfFc2nlhshxwCxr0JSQn/8ONudFdNSz"><link rel="preload" href="/farm_sim-4f29181bbdf75b40_bg.wasm" crossorigin="anonymous" integrity="sha384-Nde/pgDMDMTd1IVlwty/kPIPZBZ7vviDCRmxlXrgLuN3wfmXV7ur4wvry24cMTew" as="fetch" type="application/wasm"></head>
+  <link rel="modulepreload" href="/farm_sim-4f46c12812251bb1.js" crossorigin="anonymous" integrity="sha384-vfA4Z3YwL4/1No1U2PXafED8WaS0yvqEptfgPPSP0VviExq3bTvuL8Ep5DFCBwLB"><link rel="preload" href="/farm_sim-4f46c12812251bb1_bg.wasm" crossorigin="anonymous" integrity="sha384-SK2X13UpjUykCiGQ02duOvN15uw/ASKYZUgh8T7mvTKRXhq+KQeXkEj4Q1e4H1Ct" as="fetch" type="application/wasm"></head>
   <body>
     <div class="game-header">
       <h1 class="game-title">🌾 Farm Sim Paradise</h1>

--- a/src/farm.rs
+++ b/src/farm.rs
@@ -50,15 +50,10 @@ impl Farm {
         self.random_infest(); 
     }
 
-    pub fn plant(&mut self, row: usize, col: usize, crop: CropType) -> bool {
+    pub fn plant(&mut self, row: usize, col: usize, crop: CropType, seed_key: String) -> bool {
         if row < self.grid.len() && col < self.grid[0].len() {
             let tile = &mut self.grid[row][col];
-            let crop_str = match crop {
-                CropType::Wheat => "wheat",
-                CropType::Corn => "corn",
-                CropType::Carrot => "carrot",
-            };
-            if tile.can_plant() && self.inventory.remove_seed(crop_str) {
+            if tile.can_plant() && self.inventory.remove_seed(&seed_key) {
                 tile.state = TileState::Planted {
                     crop,
                     timer: 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,13 +179,13 @@ pub fn spray_tile(row: usize, col: usize) {
 #[wasm_bindgen]
 pub fn plant(row: usize, col: usize, crop: String) {
     let crop_type = match crop.as_str() {
-        "wheat" => CropType::Wheat,
-        "corn" => CropType::Corn,
-        "carrot" => CropType::Carrot,
+        "wheat" | "premium_wheat" | "golden_wheat" => CropType::Wheat,
+        "corn" | "premium_corn" | "golden_corn" => CropType::Corn,
+        "carrot" | "premium_carrot" | "golden_carrot" => CropType::Carrot,
         _ => CropType::Wheat,
     };
     SELECTED_CROP.with(|selected| *selected.borrow_mut() = crop_type);
-    let success = FARM.with(|farm| farm.borrow_mut().plant(row, col, crop_type));
+    let success = FARM.with(|farm| farm.borrow_mut().plant(row, col, crop_type, crop.clone()));
     if success {
         play_sound("plant_seed.mp3");
         TASKS.with(|tasks| {
@@ -513,7 +513,12 @@ fn start_render_loop() -> Result<(), JsValue> {
                     "#,
                     balance,
                     seeds.iter().map(|(item, count)| {
-                        let img_src = format!("{}.png", item);
+                        let img_src = match item.as_str() {
+                            "wheat" | "premium_wheat" | "golden_wheat" => "wheat.png",
+                            "corn" | "premium_corn" | "golden_corn" => "corn.png",
+                            "carrot" | "premium_carrot" | "golden_carrot" => "carrot.png",
+                            _ => "seed.png", // 兜底
+                        };
                         format!(
                             r#"<div class="inventory-item" draggable="true" data-seed-type="{}">
                                 <img src="{}" />


### PR DESCRIPTION
### 问题描述

当玩家购买高级种子后，背包中种子图标显示为破损图片，无法拖拽到农田进行种植。

错误显示：

<img width="2136" height="1475" alt="屏幕截图 2025-07-13 211205" src="https://github.com/user-attachments/assets/00ebee41-f64d-4ab5-98e0-2890e7af53f1" />

### 根本原因

1. 前端图标渲染逻辑仅识别 `wheat`、`corn` 等基础种子名：代码中 item 直接作为图片名拼接 .png，如果 item 是 premium_wheat 或 golden_corn等扩展种子名，但没有对应图片文件，则图片无法解析。	

```rust
seeds.iter().map(|(item, count)| {
    let img_src = format!("{}.png", item);
    format!(
        r#"<div class="inventory-item" draggable="true" data-seed-type="{}">
            <img src="{}" />
            <div>x{}</div>
        </div>"#,
        item, img_src, count
    )
})
```

2. 前端传递种子key，后端只接收作物类别信息，在调用过程中，后端无法完整识别种子身份，影响了库存扣减、种植判定等逻辑，造成拖拽种植无响应。

```rust
pub fn plant(&mut self, row: usize, col: usize, crop: CropType) -> bool {
    if row < self.grid.len() && col < self.grid[0].len() {
        let tile = &mut self.grid[row][col];
        //只匹配了基础类型 Wheat、Corn、Carrot，没有扩展类型
        //即使正确匹配，crop_str 只会是基础类型传递给后端，后端无法识别和扣减正确的种子类型
        let crop_str = match crop {
            CropType::Wheat => "wheat",
            CropType::Corn => "corn",
            CropType::Carrot => "carrot",
        };
}
```



### 修复内容

#### 1. 前端图标渲染修复

在渲染种子图标时，扩展种子统一映射到对应基础图标（如 `premium_wheat`映射到`wheat.png`）。

```rust
match item.as_str() {
    "wheat" | "premium_wheat" | "golden_wheat" => "wheat.png",
    "corn" | "premium_corn" | "golden_corn" => "corn.png",
    "carrot" | "premium_carrot" => "carrot.png",
    _ => "default.png"
}

```

#### 2. 种植逻辑修复

- 种植函数 `plant(...)` 新增参数 `seed_key: String`，用于精确标识所用种子；
- 高级种子（如 `golden_corn`）通过 `seed_key` 映射为对应的 `CropType::Corn`，种植函数对于不同等级种子使用统一的作物类型来处理，确保种植逻辑支持高级种子。

##### 修改前：

```rust
pub fn plant(&mut self, row: usize, col: usize, crop: CropType) -> bool {
    if row < self.grid.len() && col < self.grid[0].len() {
        let tile = &mut self.grid[row][col];
        //只匹配了基础类型 Wheat、Corn、Carrot，没有扩展类型
        //即使正确匹配，crop_str 只会是基础类型传递给后端，后端无法识别和扣减正确的种子类型
        let crop_str = match crop {
            CropType::Wheat => "wheat",
            CropType::Corn => "corn",
            CropType::Carrot => "carrot",
        };
}
```

##### 修改后：

```rust
pub fn plant(&mut self, row: usize, col: usize, crop: CropType) -> bool {
    if row < self.grid.len() && col < self.grid[0].len() {
        let tile = &mut self.grid[row][col];
        let crop_type = match seed_key.as_str() {
            "wheat" | "premium_wheat" | "golden_wheat" => CropType::Wheat,
            "corn" | "premium_corn" | "golden_corn" => CropType::Corn,
            "carrot" | "premium_carrot" => CropType::Carrot,
            _ => return Err("未知种子类型".into()),
        };
        farm.plant(row, col, crop_type, seed_key.clone());
    };
}
```

------

### 测试验证

-  背包中高级种子图标显示正常（无破图）
- 拖动种子可以正确识别并种植
-  正确扣除指定类型种子库存
-  各类作物种子均测试通过（普通 / 高级 / 金色）
-  在 Chrome、Edge浏览器中手动验证通过（Windows 环境）

### 截图
购买高级玉米种子后成功显示图片
<img width="2151" height="1498" alt="屏幕截图 2025-07-13 225839" src="https://github.com/user-attachments/assets/4e05ab82-e785-4c13-9e80-b7b383293088" />

